### PR TITLE
GitHub Pages用の静的サイト生成設定を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -190,7 +190,7 @@ jobs:
         run: yarn install
       
       - name: Generate static site
-        run: yarn generate
+        run: yarn build:gh-pages
       
       - name: Copy current JSON file to output
         run: |

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,27 +3,22 @@ export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
   devtools: { enabled: true },
   
-  // GitHub Pages設定
+  // 静的サイト生成を有効化
+  ssr: false,
   nitro: {
     prerender: {
-      routes: ['/']
+      routes: ['/', '/supply-analysis'],
+      crawlLinks: true
     },
-    // publicディレクトリのファイルを静的アセットとして含める
-    publicAssets: [
-      {
-        baseURL: process.env.NODE_ENV === 'production' ? '/root-ranking/' : '/',
-        dir: 'public',
-        maxAge: 60 * 60 * 24 // 24時間キャッシュ
-      }
-    ],
-    // リダイレクト設定
-    routeRules: {
-      '/root-ranking': { redirect: '/' },
-      '/root-ranking/': { redirect: '/' }
+    // GitHub Pages用の設定
+    output: {
+      publicDir: '.output/public'
     }
   },
   
+  // GitHub Pages設定
   app: {
-    baseURL: '/'
+    baseURL: process.env.NODE_ENV === 'production' ? '/root-ranking/' : '/',
+    buildAssetsDir: '_nuxt/'
   }
 })

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "nuxt build",
     "dev": "nuxt dev",
     "generate": "nuxt generate && cp -r public/*.json .output/public/ 2>/dev/null || true",
+    "build:gh-pages": "NITRO_PRESET=github_pages nuxt build",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare"
   },


### PR DESCRIPTION
- Nuxt 4用の静的サイト生成設定に更新
- ssr: falseでSPAモードに設定
- prerenderで/supply-analysisページも生成対象に追加
- GitHub Actions用のbuild:gh-pagesスクリプトを追加
- 404エラーとプリロードエラーの解決を目的とした設定